### PR TITLE
Use CSV library to fix issue when decoding quoted values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,12 @@
 			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>net.sf.opencsv</groupId>
+			<artifactId>opencsv</artifactId>
+			<version>2.0</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/src/main/java/org/culturegraph/mf/stream/converter/CsvDecoder.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/CsvDecoder.java
@@ -69,7 +69,10 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
 				}
 				getReceiver().endRecord();
 			}else{
-				throw new IllegalArgumentException("wrong number of columns in input line: " + string);
+				throw new IllegalArgumentException(
+						String.format(
+								"wrong number of columns (expected %s, was %s) in input line: %s",
+								header.length, parts.length, string));
 			}
 		}else{
 			getReceiver().startRecord(String.valueOf(++count));

--- a/src/main/java/org/culturegraph/mf/stream/converter/CsvDecoder.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/CsvDecoder.java
@@ -15,7 +15,9 @@
  */
 package org.culturegraph.mf.stream.converter;
 
-import java.util.regex.Pattern;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
 
 import org.culturegraph.mf.framework.DefaultObjectPipe;
 import org.culturegraph.mf.framework.StreamReceiver;
@@ -23,42 +25,43 @@ import org.culturegraph.mf.framework.annotations.Description;
 import org.culturegraph.mf.framework.annotations.In;
 import org.culturegraph.mf.framework.annotations.Out;
 
-
+import au.com.bytecode.opencsv.CSVReader;
 
 /**
  * Decodes lines of CSV files. First line is interpreted as header.
  * 
  * @author Markus Michael Geipel
+ * @author Fabian Steeg (fsteeg)
  *
  */
 @Description("Decodes lines of CSV files. First line is interpreted as header.")
 @In(String.class)
 @Out(StreamReceiver.class)
 public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver>  {
-	
-	private static final String DEFAULT_SEP = "[\t,;]";
-	private final Pattern separator;
+
+	private static final char DEFAULT_SEP = ',';
+	private final char separator;
 	private String[] header = new String[0];
 	private int count;
 	private boolean hasHeader;
-	
+
 	/**
-	 * @param separator regexp to split lines
+	 * @param separator to split lines
 	 */
-	public CsvDecoder(final String separator) {
+	public CsvDecoder(final char separator) {
 		super();
-		this.separator = Pattern.compile(separator);
+		this.separator = separator;
 	}
-	
+
 	public CsvDecoder() {
 		super();
-		this.separator = Pattern.compile(DEFAULT_SEP);
-	}	
-	
+		this.separator = DEFAULT_SEP;
+	}
+
 	@Override
 	public void process(final String string) { 
 		assert !isClosed();
-		final String[] parts = separator.split(string);
+		final String[] parts = parseCsv(string);
 		if(hasHeader){
 			if(header.length==0){
 				header = parts;
@@ -82,7 +85,23 @@ public final class CsvDecoder extends DefaultObjectPipe<String, StreamReceiver> 
 			getReceiver().endRecord();
 		}
 	}
-	
+
+	private String[] parseCsv(final String string) {
+		String[] parts = new String[0];
+		try {
+			final CSVReader reader = new CSVReader(new StringReader(string),
+					separator);
+			final List<String[]> lines = reader.readAll();
+			if (lines.size() > 0) {
+				parts = lines.get(0);
+			}
+			reader.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return parts;
+	}
+
 	public void setHasHeader(final boolean hasHeader) {
 		this.hasHeader = hasHeader;
 	}

--- a/src/main/java/org/culturegraph/mf/stream/reader/CsvReader.java
+++ b/src/main/java/org/culturegraph/mf/stream/reader/CsvReader.java
@@ -35,7 +35,7 @@ public final class CsvReader extends ReaderBase<CsvDecoder> {
 		super(new CsvDecoder());
 	}
 	
-	public CsvReader(final String separator) {
+	public CsvReader(final char separator) {
 		super(new CsvDecoder(separator));
 	}
 	

--- a/src/test/java/org/culturegraph/mf/stream/converter/CsvDecoderTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/converter/CsvDecoderTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2014 hbz, Fabian Steeg
+ *
+ *  Licensed under the Apache License, Version 2.0 the "License";
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.culturegraph.mf.stream.converter;
+
+import static org.mockito.Mockito.inOrder;
+
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link CsvDecoder}.
+ * 
+ * @author Fabian steeg (fsteeg)
+ * 
+ */
+public final class CsvDecoderTest {
+
+	private CsvDecoder decoder;
+
+	@Mock
+	private StreamReceiver receiver;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		decoder = new CsvDecoder(',');
+		decoder.setHasHeader(true);
+		decoder.setReceiver(receiver);
+		decoder.process("h1,h2,h3");
+	}
+
+	@After
+	public void cleanup() {
+		decoder.closeStream();
+	}
+
+	@Test
+	public void testSimple() {
+		decoder.process("a,b,c");
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).startRecord("1");
+		ordered.verify(receiver).literal("h1", "a");
+		ordered.verify(receiver).literal("h2", "b");
+		ordered.verify(receiver).literal("h3", "c");
+		ordered.verify(receiver).endRecord();
+	}
+
+	@Test
+	public void testQuoted() {
+		decoder.process("a,\"b1,b2,b3\",c");
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).startRecord("1");
+		ordered.verify(receiver).literal("h1", "a");
+		ordered.verify(receiver).literal("h2", "b1,b2,b3");
+		ordered.verify(receiver).literal("h3", "c");
+		ordered.verify(receiver).endRecord();
+	}
+
+}


### PR DESCRIPTION
Replace `String#split` and regex separator with Apache-licensed CSV lib and single char separator.

See added `CsvDecoderTest` for details.
