### PR TITLE
Add PicaXmlHandler to flux-command

### DIFF
--- a/src/main/resources/flux-commands.properties
+++ b/src/main/resources/flux-commands.properties
@@ -43,6 +43,7 @@ read-beacon org.culturegraph.mf.stream.reader.BeaconReader
 handle-cg-xml org.culturegraph.mf.stream.converter.xml.CGXmlHandler
 handle-generic-xml org.culturegraph.mf.stream.converter.xml.GenericXmlHandler
 handle-marcxml org.culturegraph.mf.stream.converter.xml.MarcXmlHandler
+handle-picaxml	org.culturegraph.mf.stream.converter.xml.PicaXmlHandler
 
 # Encoders:
 encode-literals org.culturegraph.mf.stream.converter.StreamLiteralFormater


### PR DESCRIPTION
Adding the class to the flux commands completes b7c80fa7af6bb455b7023cb489591dd2f9b871c4.

See #235.