### PR TITLE
Add xml tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<targetJdk>1.6</targetJdk>
+		<targetJdk>1.8</targetJdk>
 		<antlr.version>3.5.2</antlr.version>
 	</properties>
 

--- a/src/main/java/org/culturegraph/mf/util/xml/FilenameExtractor.java
+++ b/src/main/java/org/culturegraph/mf/util/xml/FilenameExtractor.java
@@ -1,0 +1,91 @@
+/* Copyright 2013 Pascal Christoph.
+ * Licensed under the Eclipse Public License 1.0 */
+package org.culturegraph.mf.util.xml;
+
+import java.io.File;
+
+/**
+ * Provides basic methods for constructing filenames out of entities.
+ * 
+ * @author Pascal Christoph (dr0i)
+ * 
+ */
+public interface FilenameExtractor extends RecordIdentifier {
+
+	/**
+	 * Returns the encoding used to open the resource.
+	 * 
+	 * @return current default setting
+	 */
+	public String getEncoding();
+
+	/**
+	 * Sets the encoding used to open the resource.
+	 * 
+	 * @param encoding
+	 *            new encoding
+	 */
+	public void setEncoding(final String encoding);
+
+	/**
+	 * Sets the target path.
+	 * 
+	 * @param target
+	 *            the basis directory in which the files are stored
+	 */
+	public void setTarget(final String target);
+
+	/**
+	 * Sets the file's suffix.
+	 * 
+	 * @param fileSuffix
+	 *            the suffix used for the to be generated files
+	 */
+	public void setFileSuffix(final String fileSuffix);
+
+	/**
+	 * Sets the beginning of the index in the filename to extract the name of
+	 * the subfolder.
+	 * 
+	 * @param startIndex
+	 *            This marks the index'beginning.
+	 */
+	public void setStartIndex(final int startIndex);
+
+	/**
+	 * Sets the end of the index in the filename to extract the name of the
+	 * subfolder.
+	 * 
+	 * @param endIndex
+	 *            This marks the index' end.
+	 */
+	public void setEndIndex(final int endIndex);
+
+	/**
+	 * Provides functions and fields that all {@link FilenameExtractor}
+	 * implementing classes may found useful.
+	 * 
+	 * @author Pascal Christoph (dr0i)
+	 * 
+	 */
+	public class FilenameUtil {
+		String target = "tmp";
+		String encoding = "UTF-8";
+		String property = null;
+		String fileSuffix = null;
+		int startIndex = 0;
+		int endIndex = 0;
+		String filename = "test";
+
+		/**
+		 * Ensures that path exists. If not, make it.
+		 * 
+		 * @param path
+		 *            the path of the to be stored file.
+		 */
+		public void ensurePathExists(final String path) {
+			final File parent = new File(path).getAbsoluteFile().getParentFile();
+			parent.mkdirs();
+		}
+	}
+}

--- a/src/main/java/org/culturegraph/mf/util/xml/RecordIdentifier.java
+++ b/src/main/java/org/culturegraph/mf/util/xml/RecordIdentifier.java
@@ -1,0 +1,22 @@
+package org.culturegraph.mf.util.xml;
+
+/**
+ * This interface declares methods for setting variables used by all record
+ * sinks.
+ * 
+ * @author dr0i
+ * 
+ */
+public interface RecordIdentifier {
+
+	/**
+	 * Sets the name property which will be used to create the name of the
+	 * record of the sink. The value of this property should lead to a unique
+	 * name because it will override existing ones.
+	 * 
+	 * @param property
+	 *            the property which will be used to extract a record name.
+	 */
+	public void setProperty(final String property);
+
+}

--- a/src/main/java/org/culturegraph/mf/util/xml/XmlEntitySplitter.java
+++ b/src/main/java/org/culturegraph/mf/util/xml/XmlEntitySplitter.java
@@ -1,0 +1,186 @@
+/** Copyright 2013,214 hbz, Pascal Christoph.
+ * Licensed under the Eclipse Public License 1.0 
+ **/
+package org.culturegraph.mf.util.xml;
+
+import java.util.HashSet;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.culturegraph.mf.framework.DefaultXmlPipe;
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.framework.XmlReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+
+/**
+ * An XML entity splitter.
+ * 
+ * @author Pascal Christoph (dr0i)
+ * 
+ */
+@Description("Splits all entities (aka records) residing in one XML document into multiple single XML documents.")
+@In(XmlReceiver.class)
+@Out(StreamReceiver.class)
+public final class XmlEntitySplitter extends DefaultXmlPipe<StreamReceiver> {
+
+	private String entity;
+	private StringBuilder builder = new StringBuilder();
+	private HashSet<String> namespaces = new HashSet<>();
+	private boolean inEntity = false;
+	private int recordCnt = 0;
+	private String root;
+	private String rootStart = "";
+	private String rootEnd = "";
+	private String xmlDeclaration = "<?xml version = \"1.0\" encoding = \"UTF-8\"?>";
+	private int entityDepth = 0;
+
+	/**
+	 * default constructor
+	 */
+	public XmlEntitySplitter() {
+	}
+
+	/**
+	 * enriched constructor setting the top level element and the entity name
+	 * 
+	 * @param aTopLevelElement
+	 *            the name of the top level XML tag
+	 * @param aEntityName
+	 *            the name of the tag defining a new entity to be split
+	 */
+	public XmlEntitySplitter(String aTopLevelElement, String aEntityName) {
+		setTopLevelElement(aTopLevelElement);
+		setEntityName(aEntityName);
+	}
+
+	/**
+	 * Sets the name of the entity. All these entities in the XML stream will be
+	 * XML documents on their own.
+	 * 
+	 * @param name
+	 *            Identifies the entities
+	 */
+	public void setEntityName(final String name) {
+		this.entity = name;
+	}
+
+	/**
+	 * Sets the top-level XML document element.
+	 * 
+	 * @param root
+	 *            the top level element. Don't set it to omit setting top level
+	 *            element.
+	 */
+	public void setTopLevelElement(final String root) {
+		this.root = root;
+		this.rootStart = "<" + root;
+		this.rootEnd = "</" + root + ">";
+	}
+
+	/**
+	 * Sets the XML declaration.
+	 * 
+	 * @param xmlDeclaration
+	 *            the xml declaration. Default is '<?xml version = "1.0"
+	 *            encoding = "UTF-8"?>'. If empty value is given, the xml
+	 *            declaration is skipped.
+	 */
+	public void setXmlDeclaration(final String xmlDeclaration) {
+		this.xmlDeclaration = xmlDeclaration;
+	}
+
+	@Override
+	public void startPrefixMapping(String prefix, String uri) throws SAXException {
+		super.startPrefixMapping(prefix, uri);
+		if (root != null & !prefix.isEmpty() && uri != null) {
+			namespaces.add(" xmlns:" + prefix + "=\"" + uri + "\"");
+		}
+	}
+
+	@Override
+	public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
+			throws SAXException {
+		if (!inEntity) {
+			if (entity.equals(localName)) {
+				builder = new StringBuilder();
+				getReceiver().startRecord(String.valueOf(this.recordCnt++));
+				inEntity = true;
+				appendValuesToEntity(qName, attributes);
+				entityDepth++;
+			}
+		} else {
+			if (entity.equals(localName)) {
+				entityDepth++;
+			}
+			appendValuesToEntity(qName, attributes);
+		}
+	}
+
+	private void appendValuesToEntity(final String qName, final Attributes attributes) {
+		this.builder.append("<" + qName);
+		if (attributes.getLength() > 0) {
+			for (int i = 0; i < attributes.getLength(); i++) {
+				builder.append(" " + attributes.getQName(i) + "=\""
+						+ StringEscapeUtils.escapeXml(attributes.getValue(i)) + "\"");
+			}
+		}
+
+		builder.append(">");
+	}
+
+	@Override
+	public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+		if (inEntity) {
+			builder.append("</" + qName + ">");
+			if (entity.equals(localName)) {
+				if (entityDepth <= 1) {
+					StringBuilder sb = new StringBuilder(xmlDeclaration + rootStart);
+					if (this.root != null && namespaces.size() > 0) {
+						for (String ns : namespaces) {
+							sb.append(ns);
+						}
+						sb.append(">");
+					}
+					builder.insert(0, sb.toString()).append(rootEnd);
+					getReceiver().literal("entity", builder.toString());
+					getReceiver().endRecord();
+					reset();
+					return;
+				}
+				entityDepth--;
+			}
+		}
+	}
+
+	@Override
+	public void characters(final char[] chars, final int start, final int length) throws SAXException {
+		try {
+			builder.append(StringEscapeUtils.escapeXml(new String(chars, start, length)));
+		} catch (Exception e) {
+			reset();
+		}
+	}
+
+	private void reset() {
+		inEntity = false;
+		builder = new StringBuilder();
+		entityDepth = 0;
+	}
+
+	/**
+	 * Returns the XML declaration.
+	 * 
+	 * @return the XML decalration
+	 */
+	public String getXmlDeclaration() {
+		return xmlDeclaration;
+	}
+
+	@Override
+	public void onResetStream() {
+		reset();
+	}
+}

--- a/src/main/java/org/culturegraph/mf/util/xml/XmlFilenameWriter.java
+++ b/src/main/java/org/culturegraph/mf/util/xml/XmlFilenameWriter.java
@@ -1,0 +1,151 @@
+/* Copyright 2013 Pascal Christoph, hbz. 
+ * Licensed under the Eclipse Public License 1.0 */
+
+package org.culturegraph.mf.util.xml;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
+import java.io.Writer;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorOutputStream;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.culturegraph.mf.exceptions.MetafactureException;
+import org.culturegraph.mf.framework.DefaultStreamPipe;
+import org.culturegraph.mf.framework.ObjectReceiver;
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.InputSource;
+
+/**
+ * A sink, writing an xml file. The filename is constructed from the xpath given
+ * via setProperty().
+ * 
+ * @author Pascal Christoph
+ */
+@Description("Writes the xml into the filesystem. The filename is constructed from the xpath given as 'property'.\n"
+		+ " Variables are\n" + "- 'target' (determining the output directory)\n"
+		+ "- 'property' (the element in the XML entity. Constitutes the main part of the file's name.)\n"
+		+ "- 'startIndex' ( a subfolder will be extracted out of the filename. This marks the index' beginning )\n"
+		+ "- 'stopIndex' ( a subfolder will be extracted out of the filename. This marks the index' end )\n")
+@In(StreamReceiver.class)
+@Out(Void.class)
+public final class XmlFilenameWriter extends DefaultStreamPipe<ObjectReceiver<String>>implements FilenameExtractor {
+	private static final Logger LOG = LoggerFactory.getLogger(XmlFilenameWriter.class);
+	private static final XPath xPath = XPathFactory.newInstance().newXPath();
+
+	private FilenameUtil filenameUtil = new FilenameUtil();
+	private String compression;
+
+	/**
+	 * Default constructor
+	 */
+	public XmlFilenameWriter() {
+		setFileSuffix(".xml");
+	}
+
+	/**
+	 * Sets the compression, if any. Default is no compression.
+	 * 
+	 * @param compression
+	 *            The compression. At the moment only 'bz2' is possible.
+	 */
+	public void setCompression(String compression) {
+		this.compression = compression;
+	}
+
+	@Override
+	public void literal(final String str, String xml) {
+		String identifier = null;
+		try {
+			identifier = xPath.evaluate(filenameUtil.property, new InputSource(new StringReader(xml)));
+		} catch (XPathExpressionException e2) {
+			e2.printStackTrace();
+		}
+		if (identifier == null || identifier.length() < filenameUtil.endIndex) {
+			LOG.info("No identifier found, skip writing");
+			LOG.debug("the xml:" + xml);
+			return;
+		}
+		String directory = identifier;
+		if (directory.length() >= filenameUtil.endIndex) {
+			directory = directory.substring(filenameUtil.startIndex, filenameUtil.endIndex);
+		}
+		final String file = FilenameUtils.concat(filenameUtil.target,
+				FilenameUtils.concat(directory + File.separator, identifier + filenameUtil.fileSuffix));
+		filenameUtil.ensurePathExists(file);
+		try {
+			if (this.compression == null) {
+				final Writer writer = new OutputStreamWriter(new FileOutputStream(file), filenameUtil.encoding);
+				IOUtils.write(xml, writer);
+				writer.close();
+			} else {
+				if (this.compression.equals("bz2")) {
+					final OutputStream out = new FileOutputStream(file + ".bz2");
+					CompressorOutputStream cos = new CompressorStreamFactory()
+							.createCompressorOutputStream(CompressorStreamFactory.BZIP2, out);
+					IOUtils.copy(new StringReader(xml), cos);
+					cos.close();
+					out.close();
+				}
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+			throw new MetafactureException(e);
+		} catch (CompressorException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public String getEncoding() {
+		return filenameUtil.encoding;
+	}
+
+	@Override
+	public void setEncoding(String encoding) {
+		filenameUtil.encoding = encoding;
+
+	}
+
+	@Override
+	public void setTarget(String target) {
+		filenameUtil.target = target;
+	}
+
+	@Override
+	public void setProperty(String property) {
+		filenameUtil.property = property;
+	}
+
+	@Override
+	public void setFileSuffix(String fileSuffix) {
+		filenameUtil.fileSuffix = fileSuffix;
+
+	}
+
+	@Override
+	public void setStartIndex(int startIndex) {
+		filenameUtil.startIndex = startIndex;
+
+	}
+
+	@Override
+	public void setEndIndex(int endIndex) {
+		filenameUtil.endIndex = endIndex;
+	}
+}

--- a/src/main/java/org/culturegraph/mf/util/xml/XmlTee.java
+++ b/src/main/java/org/culturegraph/mf/util/xml/XmlTee.java
@@ -1,0 +1,169 @@
+/* Copyright 2013 hbz, Pascal Christoph.
+ * Licensed under the Eclipse Public License 1.0 */
+package org.culturegraph.mf.util.xml;
+
+import java.io.IOException;
+
+import org.culturegraph.mf.framework.DefaultTee;
+import org.culturegraph.mf.framework.XmlPipe;
+import org.culturegraph.mf.framework.XmlReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/**
+ * Sends one {@XmlReceiver} to two {@XmlReceiver}.
+ * 
+ * @author Pascal Christoph (dr0i)
+ * 
+ */
+@Description("Sends an object to more than one receiver.")
+@In(XmlReceiver.class)
+@Out(XmlReceiver.class)
+public final class XmlTee extends DefaultTee<XmlReceiver>implements XmlPipe<XmlReceiver> {
+
+	@Override
+	public void characters(char[] ch, int start, int length) throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.characters(ch, start, length);
+		}
+	}
+
+	@Override
+	public void endDocument() throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.endDocument();
+		}
+	}
+
+	@Override
+	public void endElement(String uri, String localName, String qName) throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.endElement(uri, localName, qName);
+		}
+	}
+
+	@Override
+	public void endPrefixMapping(String prefix) throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.endPrefixMapping(prefix);
+		}
+	}
+
+	@Override
+	public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void processingInstruction(String target, String data) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void setDocumentLocator(Locator locator) {
+		// unused
+	}
+
+	@Override
+	public void skippedEntity(String name) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void startDocument() throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.startDocument();
+		}
+	}
+
+	@Override
+	public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.startElement(uri, localName, qName, atts);
+		}
+	}
+
+	@Override
+	public void startPrefixMapping(String prefix, String uri) throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.startPrefixMapping(prefix, uri);
+		}
+	}
+
+	@Override
+	public void notationDecl(String name, String publicId, String systemId) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void unparsedEntityDecl(String name, String publicId, String systemId, String notationName)
+			throws SAXException {
+		// unused
+	}
+
+	@Override
+	public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+		return null;
+	}
+
+	@Override
+	public void error(SAXParseException exception) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void fatalError(SAXParseException exception) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void warning(SAXParseException exception) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void comment(char[] ch, int start, int length) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void endCDATA() throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void endDTD() throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void endEntity(String name) throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.endEntity(name);
+		}
+	}
+
+	@Override
+	public void startCDATA() throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void startDTD(String name, String publicId, String systemId) throws SAXException {
+		// unused
+	}
+
+	@Override
+	public void startEntity(String name) throws SAXException {
+		for (XmlReceiver receiver : getReceivers()) {
+			receiver.startEntity(name);
+		}
+	}
+
+}

--- a/src/test/java/org/culturegraph/mf/util/xml/XmlEntitySplitterTest.java
+++ b/src/test/java/org/culturegraph/mf/util/xml/XmlEntitySplitterTest.java
@@ -1,0 +1,44 @@
+/* Copyright 2013  Pascal Christoph.
+ * Licensed under the Eclipse Public License 1.0 */
+package org.culturegraph.mf.util.xml;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+import org.culturegraph.mf.stream.converter.xml.XmlDecoder;
+import org.culturegraph.mf.stream.sink.EventList;
+import org.culturegraph.mf.stream.sink.StreamValidator;
+import org.culturegraph.mf.stream.source.FileOpener;
+import org.junit.Test;
+
+/**
+ * @author Pascal Christoph
+ * 
+ */
+@SuppressWarnings("javadoc")
+public class XmlEntitySplitterTest {
+
+	@Test
+	public void testFlow() throws URISyntaxException {
+		final FileOpener opener = new FileOpener();
+		final XmlDecoder xmldecoder = new XmlDecoder();
+		final XmlEntitySplitter xmlsplitter = new XmlEntitySplitter();
+		xmlsplitter.setEntityName("Description");
+		xmlsplitter.setTopLevelElement("rdf:RDF");
+		final EventList expected = new EventList();
+		expected.startRecord("0");
+		expected.literal("entity", xmlsplitter.getXmlDeclaration()
+				+ "<rdf:RDF xmlns:rdf=\"ns#\"><rdf:Description rdf:about=\"1\"> <a rdf:resource=\"r1\">1</a></rdf:Description></rdf:RDF>");
+		expected.endRecord();
+		expected.startRecord("1");
+		expected.literal("entity", xmlsplitter.getXmlDeclaration()
+				+ "<rdf:RDF xmlns:rdf=\"ns#\"><rdf:Description rdf:about=\"2\"> <a rdf:resource=\"r2\">2</a></rdf:Description></rdf:RDF>");
+		expected.endRecord();
+		final StreamValidator validator = new StreamValidator(expected.getEvents());
+		opener.setReceiver(xmldecoder).setReceiver(xmlsplitter).setReceiver(validator);
+		File infile = new File(
+				Thread.currentThread().getContextClassLoader().getResource("data/XmlEntiteesToBeSplitted.xml").toURI());
+		opener.process(infile.getAbsolutePath());
+		opener.closeStream();
+	}
+}

--- a/src/test/resources/data/XmlEntiteesToBeSplitted.xml
+++ b/src/test/resources/data/XmlEntiteesToBeSplitted.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="ns#">
+  <rdf:Description rdf:about="1"> <a rdf:resource="r1">1</a></rdf:Description>
+  <rdf:Description rdf:about="2"> <a rdf:resource="r2">2</a></rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
As the two tools introduced hereby, XmlEntitySplitter and XmlFilenameWriter, have already proved to be useful in two different metafacture based projects, it seems to be desirable to have them being included within the framework.