### PR TITLE
Add AlephMabXmlHandler

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandler.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandler.java
@@ -26,9 +26,9 @@ import org.xml.sax.SAXException;
 
 /**
  * An Aleph-MAB-XML reader.
- * 
+ *
  * @author Pascal Christoph (dr0i)
- * 
+ *
  */
 @Description("A MAB XML reader")
 @In(XmlReceiver.class)
@@ -48,43 +48,46 @@ public final class AlephMabXmlHandler extends DefaultXmlPipe<StreamReceiver> {
 	private StringBuilder builder = new StringBuilder();
 
 	@Override
-	public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
+	public void characters(final char[] chars, final int start, final int length)
 			throws SAXException {
-		if (CONTROLLFIELD.equals(localName)) {
-			builder = new StringBuilder();
-			currentTag = "";
-			getReceiver().startEntity(attributes.getValue(DATAFIELD_ATTRIBUTE));
-		} else if (SUBFIELD.equals(localName)) {
-			builder = new StringBuilder();
-			currentTag = attributes.getValue(SUBFIELD_ATTRIBUTE);
-		} else if (DATAFIELD.equals(localName)) {
-			getReceiver().startEntity(attributes.getValue(DATAFIELD_ATTRIBUTE) + attributes.getValue(INDICATOR1)
-					+ attributes.getValue(INDICATOR2));
-		} else if (RECORD.equals(localName)) {
-			getReceiver().startRecord("");
-		} else if (LEADER.equals(localName)) {
-			builder = new StringBuilder();
-			currentTag = LEADER;
-		}
+		this.builder.append(chars, start, length);
 	}
 
 	@Override
-	public void endElement(final String uri, final String localName, final String qName) throws SAXException {
-		if (CONTROLLFIELD.equals(localName)) {
-			getReceiver().literal(currentTag, builder.toString().trim());
+	public void endElement(final String uri, final String localName, final String qName)
+			throws SAXException {
+		if (AlephMabXmlHandler.CONTROLLFIELD.equals(localName)) {
+			getReceiver().literal(this.currentTag, this.builder.toString().trim());
 			getReceiver().endEntity();
-		} else if (SUBFIELD.equals(localName)) {
-			getReceiver().literal(currentTag, builder.toString().trim());
-		} else if (DATAFIELD.equals(localName)) {
+		} else if (AlephMabXmlHandler.SUBFIELD.equals(localName)) {
+			getReceiver().literal(this.currentTag, this.builder.toString().trim());
+		} else if (AlephMabXmlHandler.DATAFIELD.equals(localName)) {
 			getReceiver().endEntity();
-		} else if (RECORD.equals(localName)) {
+		} else if (AlephMabXmlHandler.RECORD.equals(localName)) {
 			getReceiver().endRecord();
 		}
 	}
 
 	@Override
-	public void characters(final char[] chars, final int start, final int length) throws SAXException {
-		builder.append(chars, start, length);
+	public void startElement(final String uri, final String localName, final String qName,
+			final Attributes attributes) throws SAXException {
+		if (AlephMabXmlHandler.CONTROLLFIELD.equals(localName)) {
+			this.builder = new StringBuilder();
+			this.currentTag = "";
+			getReceiver().startEntity(attributes.getValue(AlephMabXmlHandler.DATAFIELD_ATTRIBUTE));
+		} else if (AlephMabXmlHandler.SUBFIELD.equals(localName)) {
+			this.builder = new StringBuilder();
+			this.currentTag = attributes.getValue(AlephMabXmlHandler.SUBFIELD_ATTRIBUTE);
+		} else if (AlephMabXmlHandler.DATAFIELD.equals(localName)) {
+			getReceiver().startEntity(attributes.getValue(AlephMabXmlHandler.DATAFIELD_ATTRIBUTE)
+					+ attributes.getValue(AlephMabXmlHandler.INDICATOR1)
+					+ attributes.getValue(AlephMabXmlHandler.INDICATOR2));
+		} else if (AlephMabXmlHandler.RECORD.equals(localName)) {
+			getReceiver().startRecord("");
+		} else if (AlephMabXmlHandler.LEADER.equals(localName)) {
+			this.builder = new StringBuilder();
+			this.currentTag = AlephMabXmlHandler.LEADER;
+		}
 	}
 
 }

--- a/src/main/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandler.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandler.java
@@ -1,0 +1,90 @@
+/** Copyright 2013,2014 hbz
+ *
+ *  Licensed under the Apache License, Version 2.0 the "License";
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.culturegraph.mf.stream.converter.xml;
+
+import org.culturegraph.mf.framework.DefaultXmlPipe;
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.framework.XmlReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+
+/**
+ * An Aleph-MAB-XML reader.
+ * 
+ * @author Pascal Christoph (dr0i)
+ * 
+ */
+@Description("A MAB XML reader")
+@In(XmlReceiver.class)
+@Out(StreamReceiver.class)
+public final class AlephMabXmlHandler extends DefaultXmlPipe<StreamReceiver> {
+
+	private static final String SUBFIELD = "subfield";
+	private static final String DATAFIELD = "datafield";
+	private static final String CONTROLLFIELD = "controlfield";
+	private static final String RECORD = "ListRecords";
+	private static final String LEADER = "leader";
+	private static final String DATAFIELD_ATTRIBUTE = "tag";
+	private static final String SUBFIELD_ATTRIBUTE = "code";
+	private static final String INDICATOR1 = "ind1";
+	private static final String INDICATOR2 = "ind2";
+	private String currentTag = "";
+	private StringBuilder builder = new StringBuilder();
+
+	@Override
+	public void startElement(final String uri, final String localName, final String qName, final Attributes attributes)
+			throws SAXException {
+		if (CONTROLLFIELD.equals(localName)) {
+			builder = new StringBuilder();
+			currentTag = "";
+			getReceiver().startEntity(attributes.getValue(DATAFIELD_ATTRIBUTE));
+		} else if (SUBFIELD.equals(localName)) {
+			builder = new StringBuilder();
+			currentTag = attributes.getValue(SUBFIELD_ATTRIBUTE);
+		} else if (DATAFIELD.equals(localName)) {
+			getReceiver().startEntity(attributes.getValue(DATAFIELD_ATTRIBUTE) + attributes.getValue(INDICATOR1)
+					+ attributes.getValue(INDICATOR2));
+		} else if (RECORD.equals(localName)) {
+			getReceiver().startRecord("");
+		} else if (LEADER.equals(localName)) {
+			builder = new StringBuilder();
+			currentTag = LEADER;
+		}
+	}
+
+	@Override
+	public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+		if (CONTROLLFIELD.equals(localName)) {
+			getReceiver().literal(currentTag, builder.toString().trim());
+			getReceiver().endEntity();
+		} else if (SUBFIELD.equals(localName)) {
+			getReceiver().literal(currentTag, builder.toString().trim());
+		} else if (DATAFIELD.equals(localName)) {
+			getReceiver().endEntity();
+		} else if (RECORD.equals(localName)) {
+			getReceiver().endRecord();
+		}
+	}
+
+	@Override
+	public void characters(final char[] chars, final int start, final int length) throws SAXException {
+		builder.append(chars, start, length);
+	}
+
+}

--- a/src/main/resources/flux-commands.properties
+++ b/src/main/resources/flux-commands.properties
@@ -43,6 +43,7 @@ read-beacon org.culturegraph.mf.stream.reader.BeaconReader
 handle-cg-xml org.culturegraph.mf.stream.converter.xml.CGXmlHandler
 handle-generic-xml org.culturegraph.mf.stream.converter.xml.GenericXmlHandler
 handle-marcxml org.culturegraph.mf.stream.converter.xml.MarcXmlHandler
+handle-mabxml org.culturegraph.mf.stream.converter.xml.AlephMabXmlHandler
 
 # Encoders:
 encode-literals org.culturegraph.mf.stream.converter.StreamLiteralFormater

--- a/src/test/java/org/culturegraph/mf/stream/DataFilePath.java
+++ b/src/test/java/org/culturegraph/mf/stream/DataFilePath.java
@@ -33,6 +33,7 @@ public final class DataFilePath {
 	public static final String CG_XML = DATA_PREFIX + "cgxml_test.xml";
 	
 	public static final String GENERIC_XML = DATA_PREFIX + "generic_xml_test.xml";
+	public static final String ALEPH_MAB_XML = DATA_PREFIX + "alephmabxml.xml";
 	
 	public static final String COMPRESSED_NONE = DATA_PREFIX + "compressed.txt";
 	public static final String COMPRESSED_BZ2 = DATA_PREFIX + "compressed.txt.bz2";

--- a/src/test/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandlerTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandlerTest.java
@@ -15,8 +15,6 @@
  */
 package org.culturegraph.mf.stream.converter.xml;
 
-import static org.mockito.Mockito.inOrder;
-
 import org.culturegraph.mf.framework.StreamReceiver;
 import org.culturegraph.mf.stream.DataFilePath;
 import org.culturegraph.mf.stream.source.ResourceOpener;
@@ -25,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -39,45 +38,46 @@ public final class AlephMabXmlHandlerTest {
 	@Mock
 	private StreamReceiver receiver;
 
+	@After
+	public void cleanup() {
+		this.opener.closeStream();
+	}
+
 	@Before
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
-		opener = new ResourceOpener();
-		xmlDecoder = new XmlDecoder();
-		mabXmlHandler = new AlephMabXmlHandler();
-		opener.setReceiver(xmlDecoder).setReceiver(mabXmlHandler).setReceiver(receiver);
-	}
-
-	@After
-	public void cleanup() {
-		opener.closeStream();
+		this.opener = new ResourceOpener();
+		this.xmlDecoder = new XmlDecoder();
+		this.mabXmlHandler = new AlephMabXmlHandler();
+		this.opener.setReceiver(this.xmlDecoder).setReceiver(this.mabXmlHandler)
+				.setReceiver(this.receiver);
 	}
 
 	@Test
 	public void testShouldIgnoreCharDataNotInARecord() {
 
-		opener.process(DataFilePath.ALEPH_MAB_XML);
-		final InOrder ordered = inOrder(receiver);
-		ordered.verify(receiver).startRecord("");
-		ordered.verify(receiver).startEntity("001-1");
-		ordered.verify(receiver).literal("a", "HT010726584");
-		ordered.verify(receiver).endEntity();
-		ordered.verify(receiver).startEntity("331-1");
-		ordered.verify(receiver).literal("a", "Physics of plasmas");
-		ordered.verify(receiver).endEntity();
-		ordered.verify(receiver).startEntity("902-1");
-		ordered.verify(receiver).literal("s", "Zeitschrift");
-		ordered.verify(receiver).literal("9", "(DE-588)4067488-5");
-		ordered.verify(receiver).endEntity();
-		ordered.verify(receiver).endRecord();
-		ordered.verify(receiver).startRecord("");
-		ordered.verify(receiver).startEntity("001-1");
-		ordered.verify(receiver).literal("a", "HT018700720");
-		ordered.verify(receiver).endEntity();
-		ordered.verify(receiver).startEntity("100b1");
-		ordered.verify(receiver).literal("p", "Amrhein, Ludwig");
-		ordered.verify(receiver).endEntity();
-		ordered.verify(receiver).endRecord();
+		this.opener.process(DataFilePath.ALEPH_MAB_XML);
+		final InOrder ordered = Mockito.inOrder(this.receiver);
+		ordered.verify(this.receiver).startRecord("");
+		ordered.verify(this.receiver).startEntity("001-1");
+		ordered.verify(this.receiver).literal("a", "HT010726584");
+		ordered.verify(this.receiver).endEntity();
+		ordered.verify(this.receiver).startEntity("331-1");
+		ordered.verify(this.receiver).literal("a", "Physics of plasmas");
+		ordered.verify(this.receiver).endEntity();
+		ordered.verify(this.receiver).startEntity("902-1");
+		ordered.verify(this.receiver).literal("s", "Zeitschrift");
+		ordered.verify(this.receiver).literal("9", "(DE-588)4067488-5");
+		ordered.verify(this.receiver).endEntity();
+		ordered.verify(this.receiver).endRecord();
+		ordered.verify(this.receiver).startRecord("");
+		ordered.verify(this.receiver).startEntity("001-1");
+		ordered.verify(this.receiver).literal("a", "HT018700720");
+		ordered.verify(this.receiver).endEntity();
+		ordered.verify(this.receiver).startEntity("100b1");
+		ordered.verify(this.receiver).literal("p", "Amrhein, Ludwig");
+		ordered.verify(this.receiver).endEntity();
+		ordered.verify(this.receiver).endRecord();
 	}
 
 }

--- a/src/test/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandlerTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandlerTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2013, 2014 hbz
+ *
+ *  Licensed under the Apache License, Version 2.0 the "License";
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.culturegraph.mf.stream.converter.xml;
+
+import static org.mockito.Mockito.inOrder;
+
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.stream.DataFilePath;
+import org.culturegraph.mf.stream.source.ResourceOpener;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Pascal Christoph (dr0i)
+ */
+public final class AlephMabXmlHandlerTest {
+
+	private ResourceOpener opener;
+	private XmlDecoder xmlDecoder;
+	private AlephMabXmlHandler mabXmlHandler;
+
+	@Mock
+	private StreamReceiver receiver;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		opener = new ResourceOpener();
+		xmlDecoder = new XmlDecoder();
+		mabXmlHandler = new AlephMabXmlHandler();
+		opener.setReceiver(xmlDecoder).setReceiver(mabXmlHandler).setReceiver(receiver);
+	}
+
+	@After
+	public void cleanup() {
+		opener.closeStream();
+	}
+
+	@Test
+	public void testShouldIgnoreCharDataNotInARecord() {
+
+		opener.process(DataFilePath.ALEPH_MAB_XML);
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).startRecord("");
+		ordered.verify(receiver).startEntity("001-1");
+		ordered.verify(receiver).literal("a", "HT010726584");
+		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).startEntity("331-1");
+		ordered.verify(receiver).literal("a", "Physics of plasmas");
+		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).startEntity("902-1");
+		ordered.verify(receiver).literal("s", "Zeitschrift");
+		ordered.verify(receiver).literal("9", "(DE-588)4067488-5");
+		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).startEntity("001-1");
+		ordered.verify(receiver).literal("a", "HT018700720");
+		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).startEntity("100b1");
+		ordered.verify(receiver).literal("p", "Amrhein, Ludwig");
+		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).endRecord();
+	}
+
+}

--- a/src/test/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandlerTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/converter/xml/AlephMabXmlHandlerTest.java
@@ -69,6 +69,8 @@ public final class AlephMabXmlHandlerTest {
 		ordered.verify(receiver).literal("s", "Zeitschrift");
 		ordered.verify(receiver).literal("9", "(DE-588)4067488-5");
 		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).endRecord();
+		ordered.verify(receiver).startRecord("");
 		ordered.verify(receiver).startEntity("001-1");
 		ordered.verify(receiver).literal("a", "HT018700720");
 		ordered.verify(receiver).endEntity();

--- a/src/test/resources/data/alephmabxml.xml
+++ b/src/test/resources/data/alephmabxml.xml
@@ -1,0 +1,670 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <ListRecords>
+    <record>
+      <header>
+        <identifier>aleph-publish:005667364</identifier>
+      </header>
+      <metadata>
+        <record>
+          <leader>00000nM2.01200024------h</leader>
+          <controlfield tag="LDR">00000nM2.01200024------h</controlfield>
+          <controlfield tag="FMT">MH</controlfield>
+          <datafield tag="001" ind1="-" ind2="1">
+            <subfield code="a">HT010726584</subfield>
+          </datafield>
+          <datafield tag="002" ind1="a" ind2="1">
+            <subfield code="a">19991122</subfield>
+          </datafield>
+          <datafield tag="003" ind1="-" ind2="1">
+            <subfield code="a">20131031112801</subfield>
+          </datafield>
+          <datafield tag="016" ind1="-" ind2="1">
+            <subfield code="a">2070158-5</subfield>
+          </datafield>
+          <datafield tag="020" ind1="a" ind2="1">
+            <subfield code="a">1472746-8</subfield>
+            <subfield code="b">DNB</subfield>
+          </datafield>
+          <datafield tag="025" ind1="a" ind2="1">
+            <subfield code="a">019658389</subfield>
+          </datafield>
+          <datafield tag="025" ind1="z" ind2="1">
+            <subfield code="a">1472746-8</subfield>
+          </datafield>
+          <datafield tag="026" ind1="-" ind2="1">
+            <subfield code="a">ZDB1472746-8</subfield>
+          </datafield>
+          <controlfield tag="030">a||da||||||37</controlfield>
+          <datafield tag="036" ind1="a" ind2="1">
+            <subfield code="a">XD-US</subfield>
+          </datafield>
+          <datafield tag="037" ind1="b" ind2="1">
+            <subfield code="a">eng</subfield>
+          </datafield>
+          <controlfield tag="050">||||||||g|||||</controlfield>
+          <controlfield tag="052">p||||||a|||||||</controlfield>
+          <controlfield tag="058">cr||||||||||||</controlfield>
+          <datafield tag="070" ind1="-" ind2="1">
+            <subfield code="a">9001</subfield>
+          </datafield>
+          <datafield tag="070" ind1="a" ind2="1">
+            <subfield code="a">DNB</subfield>
+          </datafield>
+          <datafield tag="070" ind1="b" ind2="1">
+            <subfield code="a">8007</subfield>
+          </datafield>
+          <datafield tag="076" ind1="c" ind2="1">
+            <subfield code="a">ad</subfield>
+            <subfield code="a">nl</subfield>
+            <subfield code="a">ag</subfield>
+          </datafield>
+          <datafield tag="078" ind1="e" ind2="1">
+            <subfield code="a">ZDB-1-AIP</subfield>
+            <subfield code="a">ZDB-1-AIPK</subfield>
+          </datafield>
+          <datafield tag="078" ind1="i" ind2="1">
+            <subfield code="a">izdb</subfield>
+          </datafield>
+          <datafield tag="331" ind1="-" ind2="1">
+            <subfield code="a">Physics of plasmas</subfield>
+          </datafield>
+          <datafield tag="334" ind1="-" ind2="1">
+            <subfield code="a">Elektronische Ressource</subfield>
+          </datafield>
+          <datafield tag="335" ind1="-" ind2="1">
+            <subfield code="a">devoted to original contributions to and reviews of the physics of plasmas, including magnetofluid mechanics, kinetic theory and statistical mechanics of fully and partially ionized gases</subfield>
+          </datafield>
+          <datafield tag="359" ind1="-" ind2="1">
+            <subfield code="a">publ. by the American Institute of Physics</subfield>
+          </datafield>
+          <datafield tag="376" ind1="b" ind2="1">
+            <subfield code="a">PHPAEN</subfield>
+          </datafield>
+          <datafield tag="405" ind1="-" ind2="1">
+            <subfield code="a">1.1994 -</subfield>
+          </datafield>
+          <datafield tag="410" ind1="-" ind2="1">
+            <subfield code="a">[S.l.]</subfield>
+          </datafield>
+          <datafield tag="412" ind1="-" ind2="1">
+            <subfield code="a">American Institute of Physics</subfield>
+          </datafield>
+          <datafield tag="425" ind1="b" ind2="1">
+            <subfield code="a">1994</subfield>
+          </datafield>
+          <datafield tag="527" ind1="z" ind2="1">
+            <subfield code="p">CD-ROM-Ausg. ---&gt;</subfield>
+            <subfield code="a">Physics of plasmas</subfield>
+            <subfield code="9">HT013448878</subfield>
+          </datafield>
+          <datafield tag="527" ind1="z" ind2="1">
+            <subfield code="p">Druckausg. ---&gt;</subfield>
+            <subfield code="a">Physics of plasmas</subfield>
+            <subfield code="9">HT006157459</subfield>
+          </datafield>
+          <datafield tag="531" ind1="z" ind2="1">
+            <subfield code="p">Vorg.: ---&gt;</subfield>
+            <subfield code="a">Physics of fluids / B</subfield>
+            <subfield code="9">HT013889657</subfield>
+          </datafield>
+          <datafield tag="537" ind1="-" ind2="1">
+            <subfield code="a">355+C!URL-Ä.(11-10-13)</subfield>
+          </datafield>
+          <datafield tag="542" ind1="a" ind2="1">
+            <subfield code="a">1089-7674</subfield>
+          </datafield>
+          <datafield tag="545" ind1="a" ind2="1">
+            <subfield code="d">1070-664X</subfield>
+          </datafield>
+          <datafield tag="580" ind1="-" ind2="1">
+            <subfield code="a">eb559071</subfield>
+          </datafield>
+          <datafield tag="652" ind1="a" ind2="1">
+            <subfield code="a">Online-Ressource</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="1">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/?1472746</subfield>
+            <subfield code="x">EZB</subfield>
+            <subfield code="A">0</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="1">
+            <subfield code="u">http://scitation.aip.org/content/aip/journal/pop</subfield>
+            <subfield code="x">Verlag; 1.1994 -</subfield>
+            <subfield code="A">0</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="1">
+            <subfield code="u">http://scitation.aip.org/content/aip/journal/pop</subfield>
+            <subfield code="x">Verlag; 1.1994 - [-1 Jahr]</subfield>
+            <subfield code="z">Deutschlandweit zugänglich</subfield>
+            <subfield code="A">0</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="1">
+            <subfield code="u">http://search.ebscohost.com/</subfield>
+            <subfield code="x">Aggregator; 1994 -</subfield>
+            <subfield code="A">0</subfield>
+          </datafield>
+          <datafield tag="700" ind1="-" ind2="1">
+            <subfield code="a">530</subfield>
+            <subfield code="2">ZDB</subfield>
+          </datafield>
+          <datafield tag="902" ind1="-" ind2="1">
+            <subfield code="s">Plasmaphysik</subfield>
+            <subfield code="9">(DE-588)4046259-6</subfield>
+          </datafield>
+          <datafield tag="902" ind1="-" ind2="1">
+            <subfield code="s">Zeitschrift</subfield>
+            <subfield code="9">(DE-588)4067488-5</subfield>
+          </datafield>
+          <datafield tag="902" ind1="-" ind2="1">
+            <subfield code="s">Online-Publikation</subfield>
+            <subfield code="9">(DE-588)4511937-5</subfield>
+          </datafield>
+          <datafield tag="904" ind1="a" ind2="1">
+            <subfield code="a">ZDB</subfield>
+          </datafield>
+          <controlfield tag="SYS">005667364</controlfield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">L5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">A5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">R0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">R0003</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">K5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">C5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">K0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">U0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">KM001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">J5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">A0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">B0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">C0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">Q0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">M5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">M0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">N5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">L0001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">G5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">X5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">F5001</subfield>
+          </datafield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">F5010</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">Periodikum</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">Zeitschriften</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">Computerdatei im Fernzugriff</subfield>
+            <subfield code="h">Formschlagwort</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">Online-Datenbank</subfield>
+            <subfield code="h">Formschlagwort</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">Online-Dokument</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">On-line-Datenbank</subfield>
+            <subfield code="h">Formschlagwort</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">On-line-Dokument</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">Online-Ressource</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">On-line-Publikation</subfield>
+          </datafield>
+          <datafield tag="952" ind1="-" ind2="1">
+            <subfield code="s">Netzpublikation</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">294</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">386</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">465</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">6</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">385</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">467</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">38</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">38 M</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">5</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">468</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">Kob 7</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">Lan 1</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">929</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">836</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">361</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">51</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">466</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">290</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">61</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">82</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">464</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">1044</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">708</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">A 96</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">1010</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">Dü 62</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">832</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">743</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">Bi 10</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">107</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">829</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">1383</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">1393</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=RUBO</subfield>
+            <subfield code="2">B0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UBKL</subfield>
+            <subfield code="2">R3001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UGHE</subfield>
+            <subfield code="2">E0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=ULBMS</subfield>
+            <subfield code="2">M0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UBTR</subfield>
+            <subfield code="2">T0011</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UBSI</subfield>
+            <subfield code="2">S0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=USBK</subfield>
+            <subfield code="2">K0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=ZBMED</subfield>
+            <subfield code="2">KM001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=ULBB</subfield>
+            <subfield code="2">Q0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UBWUP</subfield>
+            <subfield code="2">W0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=BIBKO</subfield>
+            <subfield code="2">RL001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=BIBKO</subfield>
+            <subfield code="2">RL002</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=LBZ</subfield>
+            <subfield code="2">R0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FHBMS</subfield>
+            <subfield code="2">M5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UBBIE</subfield>
+            <subfield code="2">C0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=LLD</subfield>
+            <subfield code="2">L0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UBPB</subfield>
+            <subfield code="2">P0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UBDO</subfield>
+            <subfield code="2">U0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=ULBD</subfield>
+            <subfield code="2">X0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=BTHAC</subfield>
+            <subfield code="2">A0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=UBDU</subfield>
+            <subfield code="2">D0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FHBRS</subfield>
+            <subfield code="2">J5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FUH</subfield>
+            <subfield code="2">F0001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FHBAA</subfield>
+            <subfield code="2">A5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FHBGE</subfield>
+            <subfield code="2">G5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FHD</subfield>
+            <subfield code="2">X5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FHBK</subfield>
+            <subfield code="2">K5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FHLH</subfield>
+            <subfield code="2">L5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=FHBI</subfield>
+            <subfield code="2">C5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=LBZ</subfield>
+            <subfield code="2">R0003</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=HSNRH</subfield>
+            <subfield code="2">N5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=HRW</subfield>
+            <subfield code="2">F5001</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2="9">
+            <subfield code="u">http://www.bibliothek.uni-regensburg.de/ezeit/frontdoor.phtml?id=1472746&amp;bibid=HRWMB</subfield>
+            <subfield code="2">F5010</subfield>
+          </datafield>
+        </record>
+      </metadata>
+    </record>
+    <record>
+      <header>
+        <identifier>aleph-publish:020859990</identifier>
+      </header>
+      <metadata>
+        <record xmlns="http://www.ddb.de/professionell/mabxml/mabxml-1.xsd">
+          <leader>00872nM2.01200024------h</leader>
+          <controlfield tag="LDR">00872nM2.01200024------h</controlfield>
+          <controlfield tag="FMT">MH</controlfield>
+          <datafield tag="001" ind1="-" ind2="1">
+            <subfield code="a">HT018700720</subfield>
+          </datafield>
+          <datafield tag="002" ind1="a" ind2="1">
+            <subfield code="a">20150716</subfield>
+          </datafield>
+          <datafield tag="003" ind1="-" ind2="1">
+            <subfield code="a">20150720</subfield>
+          </datafield>
+          <datafield tag="026" ind1="-" ind2="1">
+            <subfield code="a">HBZHT018700720</subfield>
+          </datafield>
+          <controlfield tag="030">a|1uc||||||37</controlfield>
+          <datafield tag="036" ind1="a" ind2="1">
+            <subfield code="a">XA-DE</subfield>
+          </datafield>
+          <datafield tag="037" ind1="b" ind2="1">
+            <subfield code="a">ger</subfield>
+          </datafield>
+          <controlfield tag="050">||||||||g|||||</controlfield>
+          <controlfield tag="051">sr||||||</controlfield>
+          <datafield tag="070" ind1="-" ind2="1">
+            <subfield code="a">38 M</subfield>
+          </datafield>
+          <datafield tag="078" ind1="i" ind2="1">
+            <subfield code="a">iall</subfield>
+          </datafield>
+          <datafield tag="078" ind1="r" ind2="1">
+            <subfield code="a">38 M: ellinet; GND: (DE-588)16269969-4</subfield>
+          </datafield>
+          <datafield tag="080" ind1="-" ind2="1">
+            <subfield code="a">60</subfield>
+          </datafield>
+          <datafield tag="100" ind1="b" ind2="1">
+            <subfield code="p">Amrhein, Ludwig</subfield>
+            <subfield code="9">(DE-588)136371671</subfield>
+          </datafield>
+          <datafield tag="104" ind1="b" ind2="1">
+            <subfield code="p">Heusinger, Josefine</subfield>
+            <subfield code="d">1965-</subfield>
+            <subfield code="9">(DE-588)129961604</subfield>
+          </datafield>
+          <datafield tag="108" ind1="b" ind2="1">
+            <subfield code="p">Ottovay, Kathrin</subfield>
+          </datafield>
+          <datafield tag="112" ind1="b" ind2="1">
+            <subfield code="p">Wolter, Birgit</subfield>
+            <subfield code="9">(DE-588)115325859</subfield>
+          </datafield>
+          <datafield tag="200" ind1="b" ind2="1">
+            <subfield code="k">Bundeszentrale fÃ¼r Gesundheitliche AufklÃ¤rung</subfield>
+            <subfield code="9">(DE-588)2006655-7</subfield>
+          </datafield>
+          <datafield tag="201" ind1="-" ind2="1">
+            <subfield code="k">BZgA, Bundeszentrale fÃ¼r Gesundheitliche AufklÃ¤rung</subfield>
+          </datafield>
+          <datafield tag="201" ind1="-" ind2="1">
+            <subfield code="k">Deutschland</subfield>
+            <subfield code="h">Bundesrepublik</subfield>
+            <subfield code="b">Bundeszentrale fÃ¼r Gesundheitliche AufklÃ¤rung</subfield>
+          </datafield>
+          <datafield tag="201" ind1="-" ind2="1">
+            <subfield code="k">Deutschland</subfield>
+            <subfield code="b">Bundeszentrale fÃ¼r Gesundheitliche AufklÃ¤rung</subfield>
+          </datafield>
+          <datafield tag="201" ind1="-" ind2="1">
+            <subfield code="k">BZgA</subfield>
+          </datafield>
+          <datafield tag="201" ind1="-" ind2="1">
+            <subfield code="k">Federal Centre for Health Education</subfield>
+          </datafield>
+          <datafield tag="201" ind1="-" ind2="1">
+            <subfield code="k">Deutschland</subfield>
+            <subfield code="h">Bundesrepublik</subfield>
+            <subfield code="b">Federal Centre for Health Education</subfield>
+          </datafield>
+          <datafield tag="201" ind1="-" ind2="1">
+            <subfield code="k">FCHE</subfield>
+          </datafield>
+          <datafield tag="331" ind1="-" ind2="1">
+            <subfield code="a">&lt;&lt;Die&gt;&gt; Hochaltrigen</subfield>
+          </datafield>
+          <datafield tag="334" ind1="-" ind2="1">
+            <subfield code="a">Elektronische Ressource</subfield>
+          </datafield>
+          <datafield tag="335" ind1="-" ind2="1">
+            <subfield code="a">Expertise zur Lebenslage von Menschen im Alter Ã¼ber 80 Jahren</subfield>
+          </datafield>
+          <datafield tag="359" ind1="-" ind2="1">
+            <subfield code="a">Ludwig Amrhein ; Josefine Heusinger ; Kathrin Ottovay ; Birgit Wolter</subfield>
+          </datafield>
+          <datafield tag="403" ind1="-" ind2="1">
+            <subfield code="a">Aufl.: 1.3.02.15</subfield>
+          </datafield>
+          <datafield tag="410" ind1="-" ind2="1">
+            <subfield code="a">KÃ¶ln</subfield>
+          </datafield>
+          <datafield tag="412" ind1="-" ind2="1">
+            <subfield code="a">BZgA</subfield>
+          </datafield>
+          <datafield tag="425" ind1="-" ind2="1">
+            <subfield code="a">2015</subfield>
+          </datafield>
+          <datafield tag="425" ind1="a" ind2="1">
+            <subfield code="a">2015</subfield>
+          </datafield>
+          <datafield tag="433" ind1="-" ind2="1">
+            <subfield code="a">239 S. : zahlr. graph. Darst., Kt.</subfield>
+          </datafield>
+          <datafield tag="451" ind1="-" ind2="1">
+            <subfield code="a">Forschung und Praxis der GesundheitsfÃ¶rderung ; 47</subfield>
+          </datafield>
+          <datafield tag="453" ind1="-" ind2="1">
+            <subfield code="a">HT015550020</subfield>
+          </datafield>
+          <datafield tag="455" ind1="-" ind2="1">
+            <subfield code="a">47</subfield>
+          </datafield>
+          <datafield tag="456" ind1="-" ind2="1">
+            <subfield code="a">47</subfield>
+          </datafield>
+          <datafield tag="501" ind1="-" ind2="1">
+            <subfield code="a">Literaturangaben</subfield>
+          </datafield>
+          <datafield tag="540" ind1="a" ind2="1">
+            <subfield code="a">978-3-942816-61-8</subfield>
+          </datafield>
+          <datafield tag="552" ind1="a" ind2="1">
+            <subfield code="a">10.4126/38m-006326817</subfield>
+          </datafield>
+          <datafield tag="652" ind1="-" ind2="1">
+            <subfield code="a">Archivierte Online-Ressource</subfield>
+          </datafield>
+          <datafield tag="700" ind1="b" ind2="1">
+            <subfield code="a">610</subfield>
+          </datafield>
+          <controlfield tag="SYS">020859990</controlfield>
+          <datafield tag="LOW" ind1="-" ind2="1">
+            <subfield code="a">KM001</subfield>
+          </datafield>
+          <datafield tag="HID" ind1="-" ind2="1">
+            <subfield code="s">DTL2ALEPH</subfield>
+            <subfield code="c">20150717</subfield>
+            <subfield code="l">HBZ01</subfield>
+            <subfield code="h">0600</subfield>
+          </datafield>
+          <datafield tag="088" ind1=" " ind2=" ">
+            <subfield code="a">38 M</subfield>
+            <subfield code="b">00000099</subfield>
+            <subfield code="c">Elektronische Publikation</subfield>
+            <subfield code="e">keine ILL</subfield>
+          </datafield>
+          <datafield tag="655" ind1="e" ind2=" ">
+            <subfield code="u">http://digitool.hbz-nrw.de:1801/webclient/DeliveryManager?pid=6326817&amp;custom_att_2=simple_viewer</subfield>
+            <subfield code="y">BZgA_Hochaltrigen.pdf</subfield>
+            <subfield code="x">Archivierte Online-Ressource</subfield>
+          </datafield>
+        </record>
+      </metadata>
+    </record>
+  </ListRecords>
+</OAI-PMH>

--- a/src/test/resources/data/alephmabxml.xml
+++ b/src/test/resources/data/alephmabxml.xml
@@ -497,6 +497,8 @@
         </record>
       </metadata>
     </record>
+  </ListRecords>
+  <ListRecords>
     <record>
       <header>
         <identifier>aleph-publish:020859990</identifier>


### PR DESCRIPTION
This reader handles a widely used Mab-Xml derivative created by Aleph exports.
This handler was formerly known as "MabXmlHandler".

See https://github.com/lobid/lodmill/pull/201.

- add an aleph mab xml export, consisting of two documents, as a test resource
- add test