### PR TITLE
Adding new files for AseqDecoding including test case

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/converter/bib/AseqDecoder.java
+++ b/src/main/java/org/culturegraph/mf/stream/converter/bib/AseqDecoder.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2013, 2014 Deutsche Nationalbibliothek
+ *
+ *  Licensed under the Apache License, Version 2.0 the "License";
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.culturegraph.mf.stream.converter.bib;
+
+import java.util.regex.Pattern;
+
+import org.culturegraph.mf.framework.DefaultObjectPipe;
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
+
+/**
+ * Parses a raw Aseq stream. UTF-8 encoding expected. Events are handled by a
+ * {@link StreamReceiver}.
+ *
+ * @see StreamReceiver
+ *
+ * @author Lars G. Svensson
+ */
+@Description("Parses a raw Aseq record (UTF-8 encoding expected).")
+@In(String.class)
+@Out(StreamReceiver.class)
+public final class AseqDecoder extends
+		DefaultObjectPipe<String, StreamReceiver> {
+
+	private static final String FIELD_DELIMITER = "\n";
+	private static final String SUB_DELIMITER = "\u001f";
+	private static final Pattern FIELD_PATTERN = Pattern.compile(
+			FIELD_DELIMITER, Pattern.LITERAL);
+	private static final Pattern SUBFIELD_PATTERN = Pattern.compile(
+			SUB_DELIMITER, Pattern.LITERAL);
+	private static final int POS_ENCODING = 9;
+	private static final int POS_DIRECTORY = 24;
+	private static final int DIRECTORY_ENTRY_WIDTH = 12;
+	private static final int TAG_LENGTH = 3;
+	private static final int DATA_START_BEGIN = 12;
+	private static final int DATA_START_END = 17;
+
+	private static final Object ID_TAG = "001";
+	private static final String LEADER = "leader";
+	private static final int LEADER_END = 24;
+
+	private boolean checkUtf8Encoding;
+
+	@Override
+	public void process(final String record) {
+		assert !isClosed();
+		process(record, getReceiver(), this.checkUtf8Encoding);
+	}
+
+	public void setCheckUtf8Encoding(final boolean checkUtf8Encoding) {
+		this.checkUtf8Encoding = checkUtf8Encoding;
+	}
+
+	public static void process(final String record,
+			final StreamReceiver receiver) {
+		process(record, receiver, false);
+	}
+
+	public static void process(String record, final StreamReceiver receiver,
+			final boolean checkUtf8encoding) {
+		record = record.trim();
+		if (record.isEmpty()) {
+			return;
+		}
+		final String[] lines = record.split(FIELD_DELIMITER);
+		for (int i = 0; i < lines.length; i++) {
+			final String field = lines[i];
+			if (i == 0) {
+				receiver.startRecord(field.substring(0, 9));
+			}
+			final String category = field.substring(10, 15).trim();
+			final String scriptCode = field.substring(16, 17);
+			final String fieldContent = field.substring(18).trim();
+			if (!fieldContent.startsWith("$$")) {
+				receiver.literal(category, fieldContent);
+			} else {
+				receiver.startEntity(category);
+				final String[] subfields = fieldContent.split("\\$\\$");
+				for (int j = 0; j < subfields.length; j++) {
+					if (!"".equals(subfields[j])) {
+						final String subfield = subfields[j];
+						final String subfieldCode = subfield.substring(0, 1);
+						final String subfieldContent = subfield.substring(1);
+						receiver.literal(subfield.substring(0, 1),
+								subfield.substring(1));
+					}
+				}
+				receiver.endEntity();
+			}
+		}
+		receiver.endRecord();
+	}
+}

--- a/src/test/java/org/culturegraph/mf/stream/converter/bib/AseqDecoderTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/converter/bib/AseqDecoderTest.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright 2014 Christoph Böhme
+ *
+ *  Licensed under the Apache License, Version 2.0 the "License";
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.culturegraph.mf.stream.converter.bib;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for class {@link AseqEncoder}.
+ *
+ * @author Lars G. Svensson
+ *
+ */
+public final class AseqDecoderTest {
+
+	private static final String LEADER_LITERAL = "LDR";
+
+	private static final String RECORD_ID = "001304760";
+
+	private static final String FIELD_LDR = " LDR   L 00235nM2.01000024------h";
+
+	private static final String FIELD_001_a_TEST = " 001   L $$atest";
+
+	private static final String FIELD_200_TEST = "001304760 200   L $$kAckermann-Gemeinde$$9(DE-588)39042-2";
+
+	private static final String FIELD_MARKER = "\n";
+
+	private AseqDecoder aseqDecoder;
+
+	@Mock
+	private StreamReceiver receiver;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		this.aseqDecoder = new AseqDecoder();
+		this.aseqDecoder.setReceiver(this.receiver);
+	}
+
+	@After
+	public void cleanup() {
+		this.aseqDecoder.closeStream();
+	}
+
+	@Test
+	public void shouldReturnRecordId() {
+		this.aseqDecoder.process(RECORD_ID + FIELD_LDR);
+
+		final InOrder ordered = inOrder(this.receiver);
+		ordered.verify(this.receiver).startRecord(RECORD_ID);
+	}
+
+	@Test
+	public void testShouldParseRecordStartingWithRecordMarker() {
+		this.aseqDecoder.process(RECORD_ID + FIELD_LDR);
+
+		final InOrder ordered = inOrder(this.receiver);
+		ordered.verify(this.receiver).startRecord(RECORD_ID);
+		verifyLdrTest(ordered);
+		ordered.verify(this.receiver).endRecord();
+	}
+
+	@Test
+	public void testShouldParseRecordWithTwoFields() {
+		this.aseqDecoder.process(RECORD_ID + FIELD_LDR + FIELD_MARKER
+				+ RECORD_ID + FIELD_001_a_TEST + FIELD_MARKER + FIELD_200_TEST);
+		final InOrder ordered = inOrder(this.receiver);
+		ordered.verify(this.receiver).startRecord(RECORD_ID);
+		verifyLdrTest(ordered);
+		verify001_a_Test(ordered);
+		verify200(ordered);
+		ordered.verify(this.receiver).endRecord();
+	}
+
+	private void verify200(final InOrder ordered) {
+		ordered.verify(this.receiver).startEntity("200");
+		ordered.verify(this.receiver, never())
+				.literal("0", "01304760 200   L ");
+		ordered.verify(this.receiver).literal("k", "Ackermann-Gemeinde");
+		ordered.verify(this.receiver).literal("9", "(DE-588)39042-2");
+		ordered.verify(this.receiver).endEntity();
+	}
+
+	private void verify001_a_Test(final InOrder ordered) {
+		ordered.verify(this.receiver).startEntity("001");
+		ordered.verify(this.receiver).literal("a", "test");
+		ordered.verify(this.receiver).endEntity();
+	}
+
+	private void verifyLdrTest(final InOrder ordered) {
+		ordered.verify(this.receiver).literal(LEADER_LITERAL,
+				"00235nM2.01000024------h");
+	}
+}


### PR DESCRIPTION
Proposing a new decoder for the Aseq format used by e. g. ExLibris systems and a corresponding test case