### PR TITLE
Flushing PrintStream before calling toString on the underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/org/culturegraph/mf/stream/sink/ObjectStdoutWriterTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/sink/ObjectStdoutWriterTest.java
@@ -50,7 +50,8 @@ public final class ObjectStdoutWriterTest extends
 
 	@Override
 	protected String getOutput() throws IOException {
-		return stdoutBuffer.toString();
+	        System.out.flush();
+	        return stdoutBuffer.toString();
 	}
 
 }


### PR DESCRIPTION
When a PrintStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the PrintStream before invoking the underlying instances's toString(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/a/8708357/2665894) and [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a flush method before calling toString().