### PR TITLE
Add plan for module split-up

### DIFF
--- a/doc/module-split-up.txt
+++ b/doc/module-split-up.txt
@@ -40,6 +40,7 @@ metafacture-test-tools
 
 	Packages:
 		test
+		readers (expect for the BeaconReader)
 
 	Modules:
 		WellformednessChecker
@@ -225,6 +226,7 @@ metafacture-rdf
 
 	Modules:
 		RdfMacroPipe
+		BeaconReader
 
 --------------------------------------------------------------------------------
 

--- a/doc/module-split-up.txt
+++ b/doc/module-split-up.txt
@@ -47,7 +47,7 @@ metafacture-test-tools
 
 --------------------------------------------------------------------------------
 
-metafacture-core-modules
+metafacture-core
 	
 	Stability: medium
 
@@ -130,7 +130,7 @@ metafacture-core-modules
 
 --------------------------------------------------------------------------------
 	
-metafacture-extra-modules
+metafacture-extra
 	Stability: low
 
 	Depends on: metafacture-commons
@@ -143,7 +143,7 @@ metafacture-extra-modules
 
 --------------------------------------------------------------------------------
 
-metafacture-morph-modules
+metafacture-morph
 	Contains Metamorph and modules directly building on it.
 
 	Stability: medium
@@ -158,7 +158,7 @@ metafacture-morph-modules
 
 --------------------------------------------------------------------------------
 
-metafacture-stats-modules
+metafacture-stats
 	Stability: low
 
 	Modules:
@@ -170,7 +170,7 @@ metafacture-stats-modules
 
 --------------------------------------------------------------------------------
 
-metafacture-file-modules
+metafacture-file
 	Modules for reading and writing files. 
 
 	Stability: low
@@ -195,7 +195,7 @@ metafacture-file-modules
 
 --------------------------------------------------------------------------------
 
-metafacture-biblio-modules 
+metafacture-biblio
 	Modules for working with library related data formats.	
 
 	Stability: low
@@ -218,7 +218,7 @@ metafacture-biblio-modules
 
 --------------------------------------------------------------------------------
 
-metafacture-rdf-modules
+metafacture-rdf
 	Stability: low
 
 	Depends on: org.apache.commons.lang
@@ -228,7 +228,7 @@ metafacture-rdf-modules
 
 --------------------------------------------------------------------------------
 
-metafacture-csv-modules
+metafacture-csv
 	Stability: low
 
 	Depends on: net.sf.opencsv
@@ -238,7 +238,7 @@ metafacture-csv-modules
 
 --------------------------------------------------------------------------------
 
-metafacture-jdom-modules
+metafacture-jdom
 	Stability: low
 
 	Depends on: org.jdom
@@ -250,7 +250,7 @@ metafacture-jdom-modules
 
 --------------------------------------------------------------------------------
 
-metafacture-json-modules
+metafacture-json
 	Stability: low
 
 	Depends on: org,apache.commons.lang

--- a/doc/module-split-up.txt
+++ b/doc/module-split-up.txt
@@ -3,12 +3,9 @@ metafacture-framework
 	Contains the interface definitions and base classes for Metafacture modules.
 
 	Stability: high
-	
-	Packages:
-		framework
 
-	Classes:
-		Triple
+	Contents:
+		framework
 
 --------------------------------------------------------------------------------
 
@@ -19,15 +16,8 @@ metafacture-morph-api
 	Stability: high
 
 	Contents:
-		[TODO] (Collector and Funtion interfaces)
+		TODO
 
---------------------------------------------------------------------------------
-
-metafacture-morph-commons
-	Contains convenience classes for implementing functions and collectors.
-
-	Depends on: metafacture-morph-api
- 
 --------------------------------------------------------------------------------
 
 metafacture-commons

--- a/doc/module-split-up.txt
+++ b/doc/module-split-up.txt
@@ -40,11 +40,15 @@ metafacture-test-tools
 
 	Packages:
 		test
-		readers (expect for the BeaconReader)
 
 	Modules:
 		WellformednessChecker
-		StreamValidator [DEPENDS ON: metafacture-core-modules (EventList.Event)]
+		StreamValidator [DEPENDS ON: metafacture-core (EventList.Event)]
+		CGXmlReader [DEPENDS ON: metafacture-core (XmlDecoder, CGXmlHandler)]
+		FormetaReader [DEPENDS ON: metafacture-core (FormetaRecordsReader, FormetaDecoder)]
+		MarcXmlReader [DEPENDS ON: metafacture-core (XmlDecoder, MarcXmlHandler)]
+		PicaReader [DEPENDS ON: metafacture-core (LineReader, PicaDecoder)]
+		MultiFormatReader [DEPENS ON: metafacture-commons (ObjectFactory, ResourceUtil.loadProperties)]
 
 --------------------------------------------------------------------------------
 

--- a/doc/module-split-up.txt
+++ b/doc/module-split-up.txt
@@ -7,6 +7,9 @@ metafacture-framework
 	Packages:
 		framework
 
+	Classes:
+		Triple
+
 --------------------------------------------------------------------------------
 
 metafacture-morph-api
@@ -16,20 +19,50 @@ metafacture-morph-api
 	Stability: high
 
 	Contents:
-		[TODO] (Collector and Funtion interfaces, AbstractFlushingCollector ...)
+		[TODO] (Collector and Funtion interfaces)
+
+--------------------------------------------------------------------------------
+
+metafacture-morph-commons
+	Contains convenience classes for implementing functions and collectors.
+
+	Depends on: metafacture-morph-api
  
 --------------------------------------------------------------------------------
 
 metafacture-commons
-	Contains utility classes and commonly used data structures.
+	Contains utility classes, often used data structures and metafacture modules
+	which are often used internally by other modules.
 
 	Stability: medium
 
+	Depends on: metafacture-framework
+
 	Packages:
 		exceptions
-		types
 		util
 		formeta
+
+	Classes:
+		MultiMap
+		Collector
+		NamedValue
+		ListMap
+		MultiHashMap
+		ScopedHashMap
+
+	Modules:
+		EventList
+		EntityPathTracker
+		StreamBuffer
+		StreamFlattener [DEPENDS ON: EntityPathTracker]
+
+		NamedValueList [DEPENDS ON: Collector, types.NamedValue]
+		NamedValueSet [DEPENDS ON: Collector, types.NamedValue]
+		SingleValue [DEPENDS ON: Collector]
+		StringListMap [DEPENDS ON: Collector, types.ListMap]
+		StringMap [DEPENDS ON: Collector]
+		ValueSet [DEPENDS ON: Collector]
 
 --------------------------------------------------------------------------------
 
@@ -43,11 +76,11 @@ metafacture-test-tools
 
 	Modules:
 		WellformednessChecker
-		StreamValidator [DEPENDS ON: metafacture-core (EventList.Event)]
+		StreamValidator [DEPENDS ON: metafacture-commons (EventList.Event)]
 		CGXmlReader [DEPENDS ON: metafacture-core (XmlDecoder, CGXmlHandler)]
 		FormetaReader [DEPENDS ON: metafacture-core (FormetaRecordsReader, FormetaDecoder)]
-		MarcXmlReader [DEPENDS ON: metafacture-core (XmlDecoder, MarcXmlHandler)]
-		PicaReader [DEPENDS ON: metafacture-core (LineReader, PicaDecoder)]
+		MarcXmlReader [DEPENDS ON: metafacture-biblio (XmlDecoder, MarcXmlHandler)]
+		PicaReader [DEPENDS ON: metafacture-biblio (LineReader, PicaDecoder)]
 		MultiFormatReader [DEPENS ON: metafacture-commons (ObjectFactory, ResourceUtil.loadProperties)]
 
 --------------------------------------------------------------------------------
@@ -97,11 +130,9 @@ metafacture-core
 		ObjectTimer [DEPENDS ON: metafacture-commons (TimeUtil.formatDuration)]
 		RecordToEntity
 		StreamBatchMerger
-		StreamBuffer
 		StreamDeferrer
 		StreamEventDiscarder
 		StreamExceptionCatcher
-		StreamFlattener
 		StreamLogger
 		StreamMerger
 		StreamTee
@@ -111,15 +142,7 @@ metafacture-core
 		StringMatcher
 		TripleFilter
 		TripleReorder
-		EntityPathTracker
-		EventList
 		StringConcatenator
-		NamedValueList [DEPENDS ON: metafacture-commons (Collector, NamedValue)]
-		NamedValueSet [DEPENDS ON: metafacture-commons (Collector, NamedValue)]
-		SingleValue [DEPENDS ON: metafacture-commons (Collector)]
-		StringListMap [DEPENDS ON: metafacture-commons (Collector, ListMap)]
-		StringMap [DEPENDS ON: metafacture-commons (Collector)]
-		ValueSet [DEPENDS ON: metafacture-commons (Collector)]
 		HttpOpener
 		ResourceOpener [DEPENDS ON: metafacture-commons (ResourceUtil.getReader)]
 		DirReader
@@ -132,15 +155,6 @@ metafacture-core
 		SimpleXmlEncoder [DEPENDS ON: metafacture-commons (MultiMap, ResourceUtil.loadProperties)]
 		XmlTee
 		XmlElementSplitter [DEPENDS ON: org.apache.commons.lang]
-
---------------------------------------------------------------------------------
-	
-metafacture-extra
-	Stability: low
-
-	Depends on: metafacture-commons
-
-	Modules:
 		ObjectPipeDecoupler
 		StreamUnicodeNormalizer
 		UnicodeNormalizer
@@ -154,12 +168,12 @@ metafacture-morph
 	Stability: medium
 
 	Depends on: metafacture-comons
-	            metafacture-core-modules
+	            metafacture-morph-commons
 
 	Modules:
-		Metamorph [ÐEPENDS ON: metafacture-core-modules (StreamBuffer, StreamFlattener)]
-		Filter [DEPENDS ON: metafacture-core-modules (StreamBuffer, SingleValue)]
-		Splitter [DEPENDS ON: metafacture-core-modules (StreamBuffer, SingleValue)]
+		Metamorph [ÐEPENDS ON: metafacture-commons (StreamBuffer, StreamFlattener)]
+		Filter [DEPENDS ON: metafacture-commons (StreamBuffer, SingleValue)]
+		Splitter [DEPENDS ON: metafacture-commons (StreamBuffer, SingleValue)]
 
 --------------------------------------------------------------------------------
 
@@ -219,7 +233,7 @@ metafacture-biblio
 		PicaXmlHandler
 		AlephMabXmlHandler
 		OreAggregationAdder [DEPENDS ON: metafacture-commons (ListMap, ResourceUtil.loadProperties)]
-		PicaMultiscriptRemodeler [DEPENDS ON: metafacture-core-modules (StreamBuffer)]
+		PicaMultiscriptRemodeler [DEPENDS ON: metafacture-commons (StreamBuffer)]
 
 --------------------------------------------------------------------------------
 

--- a/doc/module-split-up.txt
+++ b/doc/module-split-up.txt
@@ -1,0 +1,262 @@
+
+metafacture-framework
+	Contains the interface definitions and base classes for Metafacture modules.
+
+	Stability: high
+	
+	Packages:
+		framework
+
+--------------------------------------------------------------------------------
+
+metafacture-morph-api
+	Contains the interface definitions and base classes for implementing 
+	Metamorph functions and collectors.
+
+	Stability: high
+
+	Contents:
+		[TODO] (Collector and Funtion interfaces, AbstractFlushingCollector ...)
+ 
+--------------------------------------------------------------------------------
+
+metafacture-commons
+	Contains utility classes and commonly used data structures.
+
+	Stability: medium
+
+	Packages:
+		exceptions
+		types
+		util
+		formeta
+
+--------------------------------------------------------------------------------
+
+metafacture-test-tools
+	An extension for JUnit that allows to test Metamorph scripts using JUnit.
+
+	Stability: medium
+
+	Packages:
+		test
+
+	Modules:
+		WellformednessChecker
+		StreamValidator [DEPENDS ON: metafacture-core-modules (EventList.Event)]
+
+--------------------------------------------------------------------------------
+
+metafacture-core-modules
+	
+	Stability: medium
+
+	Depends on: metafacture-commons	
+
+	Modules:
+		FormetaEncoder [DEPENDS ON: metafacture-commons (formeta)]
+		FormetaDecoder [DEPENDS ON: metafacture-commons (formeta)]
+		FormetaRecordsReader [DEPENDS ON: metafacture-commons (formeta)]
+		ObjectToLiteral
+		LiteralToObject
+		StreamToTriples [DEPENDS ON: metafacture-commons (formeta)]
+		TriplesToStream [DEPENDS ON: metafacture-commons (formeta)]
+		StringListMapToStream [DEPENDS ON: metafacture-commons (ListMap)]
+		MapToStream
+		CloseSuppressor
+		IdChangePipe
+		IdentityStreamPipe
+		LineReader
+		RecordReader
+		RegexDecoder
+		ObjectTemplate [DEPENDS ON: metafacture-commons (StringUtil.format)]
+		PojoEncoder
+		PojoDecoder
+		PreambleEpilogueAdder
+		StreamLiteralFormatter
+		SortedTripleFileFacade
+		AbstractTripleSort
+		TripleSort
+		TripleCount
+		TripleCollect [DEPENDS ON: metafacture-commons (formeta)]
+		AbstractStreamBatcher
+		StreamBatchLogger [DEPENDS ON: metafacture-commons (StringUtil.format)]
+		StreamBatchResetter
+		DuplicateObjectFilter
+		LineSplitter
+		ObjectBatchLogger [DEPENDS ON: metafacture-commons (StringUtil.format)]
+		ObjectBuffer
+		ObjectExceptionCatcher
+		ObjectLogger
+		ObjectTee
+		ObjectTimer [DEPENDS ON: metafacture-commons (TimeUtil.formatDuration)]
+		RecordToEntity
+		StreamBatchMerger
+		StreamBuffer
+		StreamDeferrer
+		StreamEventDiscarder
+		StreamExceptionCatcher
+		StreamFlattener
+		StreamLogger
+		StreamMerger
+		StreamTee
+		StreamTimer [DEPENDS ON: metafacture-commons (TimeUtil.formatDuration)]
+		StringDecoder
+		StringFilter
+		StringMatcher
+		TripleFilter
+		TripleReorder
+		EntityPathTracker
+		EventList
+		StringConcatenator
+		NamedValueList [DEPENDS ON: metafacture-commons (Collector, NamedValue)]
+		NamedValueSet [DEPENDS ON: metafacture-commons (Collector, NamedValue)]
+		SingleValue [DEPENDS ON: metafacture-commons (Collector)]
+		StringListMap [DEPENDS ON: metafacture-commons (Collector, ListMap)]
+		StringMap [DEPENDS ON: metafacture-commons (Collector)]
+		ValueSet [DEPENDS ON: metafacture-commons (Collector)]
+		HttpOpener
+		ResourceOpener [DEPENDS ON: metafacture-commons (ResourceUtil.getReader)]
+		DirReader
+		StdInOpener
+		StringReader
+		StringSender
+		XmlDecoder
+		GenericXmlHandler
+		CGXmlHandler
+		SimpleXmlEncoder [DEPENDS ON: metafacture-commons (MultiMap, ResourceUtil.loadProperties)]
+		XmlTee
+		XmlElementSplitter [DEPENDS ON: org.apache.commons.lang]
+
+--------------------------------------------------------------------------------
+	
+metafacture-extra-modules
+	Stability: low
+
+	Depends on: metafacture-commons
+
+	Modules:
+		ObjectPipeDecoupler
+		StreamUnicodeNormalizer
+		UnicodeNormalizer
+		JScriptObjectPipe [DEPENDS ON: metafacture-commons (ResourceUtil.getReader)]
+
+--------------------------------------------------------------------------------
+
+metafacture-morph-modules
+	Contains Metamorph and modules directly building on it.
+
+	Stability: medium
+
+	Depends on: metafacture-comons
+	            metafacture-core-modules
+
+	Modules:
+		Metamorph [ÐEPENDS ON: metafacture-core-modules (StreamBuffer, StreamFlattener)]
+		Filter [DEPENDS ON: metafacture-core-modules (StreamBuffer, SingleValue)]
+		Splitter [DEPENDS ON: metafacture-core-modules (StreamBuffer, SingleValue)]
+
+--------------------------------------------------------------------------------
+
+metafacture-stats-modules
+	Stability: low
+
+	Modules:
+		AbstractCountProcessor
+		CooccurrenceMetricCalculator
+		Counter
+		UniformSampler
+		Histogram
+
+--------------------------------------------------------------------------------
+
+metafacture-file-modules
+	Modules for reading and writing files. 
+
+	Stability: low
+	
+	Depends on: org.apache.commons.io
+	            org.apache.commons.compress
+
+	Modules:
+		FileOpener
+		TarReader
+		TripleObjectRetriever
+		TripleObjectWriter
+		TripleReader
+		TripleWriter
+		FileDigestCalculator
+		ConfigurableObjectWriter
+		AbstractObjectWriter
+		ObjectStdoutWriter
+		ObjectFileWriter
+		ObjectWriter
+		XmlFilenameWriter
+
+--------------------------------------------------------------------------------
+
+metafacture-biblio-modules 
+	Modules for working with library related data formats.	
+
+	Stability: low
+
+	Packages:
+		iso2709 [DEPENDS: metafacture-commons (Require, StringUtil.repeatChars)]
+
+	Modules:
+		AseqDecoder
+		MabDecoder
+		Marc21Encoder [DEPENDS ON: iso2709]
+		Marc21Decoder [DEPENDS ON: iso2709]
+		PicaEncoder
+		PicaDecoder [DEPENDS ON: metafacture-commons (StringUtil.copyToBuffer)]
+		MarcXmlHandler
+		PicaXmlHandler
+		AlephMabXmlHandler
+		OreAggregationAdder [DEPENDS ON: metafacture-commons (ListMap, ResourceUtil.loadProperties)]
+		PicaMultiscriptRemodeler [DEPENDS ON: metafacture-core-modules (StreamBuffer)]
+
+--------------------------------------------------------------------------------
+
+metafacture-rdf-modules
+	Stability: low
+
+	Depends on: org.apache.commons.lang
+
+	Modules:
+		RdfMacroPipe
+
+--------------------------------------------------------------------------------
+
+metafacture-csv-modules
+	Stability: low
+
+	Depends on: net.sf.opencsv
+
+	Modules:
+		CsvDecoder
+
+--------------------------------------------------------------------------------
+
+metafacture-jdom-modules
+	Stability: low
+
+	Depends on: org.jdom
+	            metafacture-commons
+
+	Modules:
+		StreamToJDomDocument [DEPENDS ON metafacture-commons (ResourceUtil.loadProperties)]
+		JDomDocumentToStream
+
+--------------------------------------------------------------------------------
+
+metafacture-json-modules
+	Stability: low
+
+	Depends on: org,apache.commons.lang
+	            com.fasterxml.jackson
+
+	Modules
+		JsonEncoder
+		JsonToElasticsearchBulk
+


### PR DESCRIPTION
the docs folder contains a proposal for separating the Metafacture modules which are currently in metafacture-core into different packages.

I am not really happy with this current version of the proposal as the metafacture-core-modules package contains way to many modules for my taste. Perhaps you have some ideas how we could further split up these modules. I think, it is desirable to have a small number of modules in the core-modules package as a number of other packages use modules from this package. Hence, it would be good if it were rather stable. That is much easier if it does not contain many modules.

Another open question is the naming of the Metafacture module packages. Should they using generic names or implementation specific ones? For instance, should the package that contains the modules for processing JSON with the jackson library be named metafacture-json-modules or metafacture-jackson-modules? The former would hide the implementation detail of which library was used to do the actual reading and writing. However, it is no longer possible to offer to packages for json
processing which are based on different implementations. The latter naming scheme would allow this.

Regarding the general progress of the reorganisation. All pull requests for metafacture-core are now merged. At the moment I am updating all dependencies of the core to their latest versions. Afterwards, I want to determine what needs to go into the Metamorph API package. That is
hopefully not to difficult as Metamorph is already quite independent from the rest of Metafacture. Only the xml-based test cases may cause some trouble. Once this is done, I thought of reorganising the package structure to reflect the new multi-module structure, so that the actual split up in the next release becomes easier. This last all-in-one version of Metafacture will be released as metafacture-core 4.0.0