### PR TITLE
Ignore null values in StreamUnicodeNormalizer.

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/pipe/StreamUnicodeNormalizer.java
+++ b/src/main/java/org/culturegraph/mf/stream/pipe/StreamUnicodeNormalizer.java
@@ -171,7 +171,7 @@ public final class StreamUnicodeNormalizer
 	}
 
 	private String normalize(final String string) {
-		return Normalizer.normalize(string, normalizationForm);
+		return string == null ? null : Normalizer.normalize(string, normalizationForm);
 	}
 
 }

--- a/src/test/java/org/culturegraph/mf/stream/pipe/StreamUnicodeNormalizerTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/pipe/StreamUnicodeNormalizerTest.java
@@ -106,6 +106,15 @@ public final class StreamUnicodeNormalizerTest {
 	}
 
 	@Test
+	public void shouldIgnoreNullValues() {
+		streamUnicodeNormalizer.startRecord(RECORD_ID);
+		streamUnicodeNormalizer.literal(LITERAL_NAME, null);
+		streamUnicodeNormalizer.endRecord();
+
+		verify(receiver).literal(LITERAL_NAME, null);
+	}
+
+	@Test
 	public void shouldNotNormalizeIdByDefault() {
 		streamUnicodeNormalizer.startRecord(ID_WITH_DIACRITICS);
 		streamUnicodeNormalizer.endRecord();


### PR DESCRIPTION
When inserting a StreamUnicodeNormalizer instance in its default configuration between a MarcXmlHandler and a Metamorph instance, I get a NullPointerException:

```
java.lang.NullPointerException
        at java.text.Normalizer.normalize(Normalizer.java:160)
        at org.culturegraph.mf.stream.pipe.StreamUnicodeNormalizer.normalize(StreamUnicodeNormalizer.java:174)
        at org.culturegraph.mf.stream.pipe.StreamUnicodeNormalizer.literal(StreamUnicodeNormalizer.java:168)
        at org.culturegraph.mf.stream.converter.xml.MarcXmlHandler.startElement(MarcXmlHandler.java:63)
        at org.apache.xerces.parsers.AbstractSAXParser.startElement(Unknown Source)
        at org.apache.xerces.impl.XMLNSDocumentScannerImpl.scanStartElement(Unknown Source)
        at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl$FragmentContentDispatcher.dispatch(Unknown Source)
        at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanDocument(Unknown Source)
        at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
        at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
        at org.apache.xerces.parsers.XMLParser.parse(Unknown Source)
        at org.apache.xerces.parsers.AbstractSAXParser.parse(Unknown Source)
        at org.culturegraph.mf.stream.converter.xml.XmlDecoder.process(XmlDecoder.java:65)
        at org.culturegraph.mf.stream.converter.xml.XmlDecoder.process(XmlDecoder.java:42)
        at org.culturegraph.mf.stream.source.FileOpener.process(FileOpener.java:92)
        at hbz.limetrans.LibraryMetadataTransformation.transform(LibraryMetadataTransformation.java:85)
        at hbz.limetrans.Main.main(Main.java:18)
```

This pull request adds an explicit null check in `normalize()`.