### PR TITLE
Implement NullFilter.

### DIFF
--- a/src/main/java/org/culturegraph/mf/stream/pipe/NullFilter.java
+++ b/src/main/java/org/culturegraph/mf/stream/pipe/NullFilter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 hbz
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.culturegraph.mf.stream.pipe;
+
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.culturegraph.mf.framework.annotations.Description;
+import org.culturegraph.mf.framework.annotations.In;
+import org.culturegraph.mf.framework.annotations.Out;
+import org.culturegraph.mf.framework.helpers.ForwardingStreamPipe;
+
+/**
+ * Replaces null values with replacement string, or, if replacement
+ * string is null (default), discards null values entirely.
+ *
+ * @author Jens Wille
+ *
+ */
+@Description("Discards or replaces null values")
+@In(StreamReceiver.class)
+@Out(StreamReceiver.class)
+public final class NullFilter extends ForwardingStreamPipe {
+
+	private String replacement = null;
+
+	public void setReplacement(final String replacement) {
+		this.replacement = replacement;
+	}
+
+	public String getReplacement() {
+		return replacement;
+	}
+
+	@Override
+	public void literal(final String name, final String value) {
+		if (value != null) {
+			getReceiver().literal(name, value);
+		}
+		else if (replacement != null) {
+			getReceiver().literal(name, replacement);
+		}
+	}
+
+}

--- a/src/test/java/org/culturegraph/mf/stream/pipe/NullFilterTest.java
+++ b/src/test/java/org/culturegraph/mf/stream/pipe/NullFilterTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 hbz
+ *
+ * Licensed under the Apache License, Version 2.0 the "License";
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.culturegraph.mf.stream.pipe;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.culturegraph.mf.framework.StreamReceiver;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for class {@link NullFilter}.
+ *
+ * @author Jens Wille
+ *
+ */
+public final class NullFilterTest {
+
+	private static final String RECORD_ID = "id";
+	private static final String ENTITY_NAME = "entity-name";
+	private static final String LITERAL_NAME = "literal-name";
+	private static final String LITERAL_VALUE = "literal-value";
+
+	private NullFilter nullFilter;
+
+	@Mock
+	private StreamReceiver receiver;
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		nullFilter = new NullFilter();
+		nullFilter.setReceiver(receiver);
+	}
+
+	@After
+	public void cleanup() {
+		nullFilter.closeStream();
+	}
+
+	@Test
+	public void shouldForwardAllEvents() {
+		nullFilter.startRecord(RECORD_ID);
+		nullFilter.startEntity(ENTITY_NAME);
+		nullFilter.literal(LITERAL_NAME, LITERAL_VALUE);
+		nullFilter.endEntity();
+		nullFilter.endRecord();
+
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).startRecord(RECORD_ID);
+		ordered.verify(receiver).startEntity(ENTITY_NAME);
+		ordered.verify(receiver).literal(LITERAL_NAME, LITERAL_VALUE);
+		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).endRecord();
+
+		verifyNoMoreInteractions(receiver);
+	}
+
+	@Test
+	public void shouldDiscardNullValues() {
+		nullFilter.startRecord(RECORD_ID);
+		nullFilter.startEntity(ENTITY_NAME);
+		nullFilter.literal(LITERAL_NAME, LITERAL_VALUE);
+		nullFilter.literal(LITERAL_NAME, null);
+		nullFilter.endEntity();
+		nullFilter.endRecord();
+
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).startRecord(RECORD_ID);
+		ordered.verify(receiver).startEntity(ENTITY_NAME);
+		ordered.verify(receiver).literal(LITERAL_NAME, LITERAL_VALUE);
+		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).endRecord();
+
+		verifyNoMoreInteractions(receiver);
+	}
+
+	@Test
+	public void shouldReplaceNullValues() {
+		nullFilter.setReplacement("replacement");
+
+		nullFilter.startRecord(RECORD_ID);
+		nullFilter.startEntity(ENTITY_NAME);
+		nullFilter.literal(LITERAL_NAME, LITERAL_VALUE);
+		nullFilter.literal(LITERAL_NAME, null);
+		nullFilter.endEntity();
+		nullFilter.endRecord();
+
+		final InOrder ordered = inOrder(receiver);
+		ordered.verify(receiver).startRecord(RECORD_ID);
+		ordered.verify(receiver).startEntity(ENTITY_NAME);
+		ordered.verify(receiver).literal(LITERAL_NAME, LITERAL_VALUE);
+		ordered.verify(receiver).literal(LITERAL_NAME, "replacement");
+		ordered.verify(receiver).endEntity();
+		ordered.verify(receiver).endRecord();
+
+		verifyNoMoreInteractions(receiver);
+	}
+
+}


### PR DESCRIPTION
Some modules can't handle `null` values (e.g. FormetaEncoder and SimpleXmlEncoder), which (at least) MarcXmlHandler may generate ([ref.](/culturegraph/metafacture-core/blob/master/src/main/java/org/culturegraph/mf/stream/converter/xml/MarcXmlHandler.java#L63)). There are several options to deal with this situation:

1. Fix all modules to not insert `null` values into the stream.
1. Fix all modules to handle `null` values (as has happened with StreamUnicodeNormalizer, see #262).
1. Add a new filter to discard or replace `null` values.

This pull request implements the latter option.